### PR TITLE
Destructure props in List and ListItem components

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -1,9 +1,7 @@
 // Components
 import ListItem from "./ListItem";
 
-export default function List(props) {
-  const { category } = props;
-
+export default function List({ category }) {
   return (
     <div>
       <ul className="symbol">

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,6 +1,4 @@
-export default function ListItem(props) {
-  const { subCategory, className, codeTag } = props;
-
+export default function ListItem({ subCategory, className, codeTag }) {
   return (
     <li data-clipboard-text={subCategory} className={className}>
       {codeTag ? <code>{subCategory}</code> : `${subCategory}`}


### PR DESCRIPTION
Refactors `List` and `ListItem` to destructure props directly in the function signature instead of assigning from a `props` object inside the body. This simplifies the components without changing behavior.