### PR TITLE
Deprecate React Router and use Next.js Link for navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ A simple, easy-to-use list of ASCII codes to copy and paste.
 
 - [React](https://reactjs.org/) - A declarative, efficient, and flexible JavaScript library for building user interfaces.
 - [Next.js](https://nextjs.org/) - The React framework for the web.
-- [React Router](https://www.npmjs.com/package/react-router) - A user‑obsessed, standards‑focused, multi‑strategy router you can deploy anywhere.
-- [React Router Hash Link](https://github.com/rafgraph/react-router-hash-link) - Solution for React Router not scrolling to hash links.
 - [clipboard.js](https://clipboardjs.com/) - A modern approach to copy text to clipboard.
 - [Sass](https://sass-lang.com) - CSS with superpowers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,6 @@
         "next": "^16.2.11",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.0",
-        "react-router-hash-link": "^2.4.3",
         "sass": "^1.82.0"
       },
       "devDependencies": {
@@ -2618,15 +2616,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.1.tgz",
-      "integrity": "sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -8302,6 +8291,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8774,6 +8764,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8785,6 +8776,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -8881,51 +8873,6 @@
       "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-router": {
-      "version": "6.30.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.2.tgz",
-      "integrity": "sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.2.tgz",
-      "integrity": "sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.1",
-        "react-router": "6.30.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-hash-link": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
-      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=15",
-        "react-router-dom": ">=4"
-      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -12358,11 +12305,6 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
       "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true
-    },
-    "@remix-run/router": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.1.tgz",
-      "integrity": "sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ=="
     },
     "@rtsao/scc": {
       "version": "1.1.0",
@@ -16125,7 +16067,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.13.4",
@@ -16437,6 +16380,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -16446,7 +16390,8 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
         }
       }
     },
@@ -16501,31 +16446,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
       "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true
-    },
-    "react-router": {
-      "version": "6.30.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.2.tgz",
-      "integrity": "sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==",
-      "requires": {
-        "@remix-run/router": "1.23.1"
-      }
-    },
-    "react-router-dom": {
-      "version": "6.30.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.2.tgz",
-      "integrity": "sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==",
-      "requires": {
-        "@remix-run/router": "1.23.1",
-        "react-router": "6.30.2"
-      }
-    },
-    "react-router-hash-link": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
-      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
     },
     "redent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "next": "^16.2.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0",
-    "react-router-hash-link": "^2.4.3",
     "sass": "^1.82.0"
   },
   "engines": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,8 @@
-// Dependencies
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Navigate,
-} from "react-router-dom";
-
 // Layout Component
 import Container from "./Container";
 
 function App() {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Container />} />
-        <Route path="*" element={<Navigate to="/" />} />
-      </Routes>
-    </Router>
-  );
+  return <Container />;
 }
 
 export default App;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 // Components
-import { HashLink } from "react-router-hash-link";
+import Link from "next/link";
 import Image from "next/image";
 import ThemeButton from "./ThemeButton";
 
@@ -13,7 +13,7 @@ import { HEADER_LINKS } from "../data/headerLinks";
 export default function Header({ theme, onClickTheme }) {
   return (
     <header>
-      <HashLink smooth to="#top" id="logo" aria-label="Logo home link">
+      <Link href="#top" id="logo" aria-label="Logo home link">
         <Image
           src={theme === "light" ? logoDark : logoLight}
           alt=""
@@ -21,16 +21,14 @@ export default function Header({ theme, onClickTheme }) {
           width={120}
           height={30}
         />
-      </HashLink>
+      </Link>
       <div className="overlay"></div>
       <div className="wrapper">
         <nav>
           <ul>
             {HEADER_LINKS.map((link) => (
               <li key={link.name}>
-                <HashLink smooth to={link.href}>
-                  {link.name}
-                </HashLink>
+                <Link href={link.href}>{link.name}</Link>
               </li>
             ))}
           </ul>

--- a/src/styles/App.sass
+++ b/src/styles/App.sass
@@ -34,6 +34,8 @@
 
 //------------------------------------------
 
+html
+  scroll-behavior: smooth
 
 body
   background: var(--bg-color)


### PR DESCRIPTION
Removes the `react-router-dom` and `react-router-hash-link` dependencies and migrates internal navigation to use Next.js's built-in `Link` component. The routing logic in `App.js` is simplified, and smooth scrolling is now handled via CSS rather than JavaScript libraries. These changes streamline the codebase and reduce dependency overhead.